### PR TITLE
allow usage of OpenCombine via OpenCombineShims

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "OpenCombine",
+        "repositoryURL": "https://github.com/OpenCombine/OpenCombine.git",
+        "state": {
+          "branch": null,
+          "revision": "8576f0d579b27020beccbccc3ea6844f3ddfc2c2",
+          "version": "0.14.0"
+        }
+      },
+      {
         "package": "xctest-dynamic-overlay",
         "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.0.0"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.0.0"),
+    .package(url: "https://github.com/OpenCombine/OpenCombine.git", from: "0.13.0"),
   ],
   targets: [
     .target(
@@ -26,6 +27,7 @@ let package = Package(
       dependencies: [
         .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
         .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        .product(name: "OpenCombineShim", package: "OpenCombine"),
       ]
     ),
     .testTarget(

--- a/Sources/CombineSchedulers/AnyScheduler.swift
+++ b/Sources/CombineSchedulers/AnyScheduler.swift
@@ -1,5 +1,5 @@
-#if canImport(Combine)
-  import Combine
+#if canImport(OpenCombineShim)
+  import OpenCombineShim
   import Foundation
 
   /// A type-erasing wrapper for the `Scheduler` protocol, which can be useful for being generic over
@@ -242,7 +242,7 @@
   /// time type and options type.
   public typealias AnySchedulerOf<Scheduler> = AnyScheduler<
     Scheduler.SchedulerTimeType, Scheduler.SchedulerOptions
-  > where Scheduler: Combine.Scheduler
+  > where Scheduler: CombineScheduler
 
   extension Scheduler {
     /// Wraps this scheduler with a type eraser.

--- a/Sources/CombineSchedulers/Concurrency.swift
+++ b/Sources/CombineSchedulers/Concurrency.swift
@@ -1,5 +1,5 @@
-#if canImport(Combine)
-  import Combine
+#if canImport(OpenCombineShim)
+  import OpenCombineShim
 
   extension Scheduler {
     /// Suspends the current task for at least the given duration.

--- a/Sources/CombineSchedulers/ImmediateScheduler.swift
+++ b/Sources/CombineSchedulers/ImmediateScheduler.swift
@@ -1,5 +1,5 @@
-#if canImport(Combine)
-  import Combine
+#if canImport(OpenCombineShim)
+  import OpenCombineShim
   import Foundation
 
   /// A scheduler for performing synchronous actions.
@@ -201,5 +201,5 @@
   /// the time type and options type.
   public typealias ImmediateSchedulerOf<Scheduler> = ImmediateScheduler<
     Scheduler.SchedulerTimeType, Scheduler.SchedulerOptions
-  > where Scheduler: Combine.Scheduler
+  > where Scheduler: CombineScheduler
 #endif

--- a/Sources/CombineSchedulers/Internal/Deprecations.swift
+++ b/Sources/CombineSchedulers/Internal/Deprecations.swift
@@ -1,5 +1,5 @@
-#if canImport(Combine)
-  import Combine
+#if canImport(OpenCombineShim)
+  import OpenCombineShim
   import Foundation
 
   // NB: Soft-deprecated after 0.5.3:

--- a/Sources/CombineSchedulers/Internal/Lock.swift
+++ b/Sources/CombineSchedulers/Internal/Lock.swift
@@ -42,4 +42,38 @@
       os_unfair_lock_unlock(self)
     }
   }
+
+#elseif os(Windows)
+
+import WinSDK
+
+typealias Lock = UnsafeMutablePointer<CRITICAL_SECTION>
+
+extension UnsafeMutablePointer where Pointee == CRITICAL_SECTION {
+    init() {
+        let cs: UnsafeMutablePointer<CRITICAL_SECTION> = .allocate(capacity: 1)
+        InitializeCriticalSection(cs)
+        self = cs
+    }
+
+    func cleanupLock() {
+        DeleteCriticalSection(self)
+        deallocate()
+    }
+
+    func lock() {
+        EnterCriticalSection(self)
+    }
+
+    func tryLock() -> Bool {
+        let result = TryEnterCriticalSection(self)
+        return result
+    }
+
+    func unlock() {
+        LeaveCriticalSection(self)
+    }
+}
+
+
 #endif

--- a/Sources/CombineSchedulers/OpenCombineAliases.swift
+++ b/Sources/CombineSchedulers/OpenCombineAliases.swift
@@ -1,0 +1,9 @@
+#if canImport(Combine)
+import Combine
+public typealias CombineScheduler = Combine.Scheduler
+
+#elseif canImport(OpenCombine)
+import OpenCombine
+public typealias CombineScheduler = OpenCombine.Scheduler
+
+#endif

--- a/Sources/CombineSchedulers/SwiftUI.swift
+++ b/Sources/CombineSchedulers/SwiftUI.swift
@@ -1,5 +1,5 @@
-#if canImport(Combine)
-  import Combine
+#if canImport(OpenCombineShim) && canImport(SwiftUI)
+  import OpenCombineShim
   import SwiftUI
 
   extension Scheduler {

--- a/Sources/CombineSchedulers/TestScheduler.swift
+++ b/Sources/CombineSchedulers/TestScheduler.swift
@@ -1,5 +1,5 @@
-#if canImport(Combine)
-  import Combine
+#if canImport(OpenCombineShim)
+  import OpenCombineShim
   import ConcurrencyExtras
   import Foundation
 
@@ -283,5 +283,23 @@
   /// time type and options type.
   public typealias TestSchedulerOf<Scheduler> = TestScheduler<
     Scheduler.SchedulerTimeType, Scheduler.SchedulerOptions
-  > where Scheduler: Combine.Scheduler
+  > where Scheduler: CombineScheduler
+
+  extension Task where Success == Failure, Failure == Never {
+    // NB: We would love if this was not necessary. See this forum post for more information:
+    //     https://forums.swift.org/t/reliably-testing-code-that-adopts-swift-concurrency/57304
+    static func megaYield(count: Int = defaultMegaYieldCount) async {
+      for _ in 0..<count {
+        await Task<Void, Never>.detached(priority: .background) { await Task.yield() }.value
+      }
+    }
+  }
+
+  let defaultMegaYieldCount = max(
+    0,
+    min(
+      ProcessInfo.processInfo.environment["TASK_MEGA_YIELD_COUNT"].flatMap(Int.init) ?? 20,
+      10_000
+    )
+  )
 #endif

--- a/Sources/CombineSchedulers/Timer.swift
+++ b/Sources/CombineSchedulers/Timer.swift
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 // Only support 64bit
-#if !(os(iOS) && (arch(i386) || arch(arm))) && canImport(Combine)
-  import Combine
+#if !(os(iOS) && (arch(i386) || arch(arm))) && canImport(OpenCombineShim)
+  import OpenCombineShim
   import Foundation
 
   @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
@@ -80,7 +80,7 @@
     /// scheduler.advance(by: 1_000)
     /// XCTAssertEqual(output, Array(0...1_001))
     /// ```
-    public final class Timer<Scheduler: Combine.Scheduler>: ConnectablePublisher {
+    public final class Timer<Scheduler: CombineScheduler>: ConnectablePublisher {
       public typealias Output = Scheduler.SchedulerTimeType
       public typealias Failure = Never
 
@@ -330,7 +330,7 @@
           demand += n
         }
 
-        @objc
+        // @objc
         func timerFired() {
           lock.lock()
           guard let ds = downstream, let parent = self.parent else {

--- a/Sources/CombineSchedulers/UIKit.swift
+++ b/Sources/CombineSchedulers/UIKit.swift
@@ -1,5 +1,5 @@
-#if canImport(UIKit) && !os(watchOS) && canImport(Combine)
-  import Combine
+#if canImport(UIKit) && !os(watchOS) && canImport(OpenCombineShim)
+  import OpenCombineShim
   import UIKit
 
   extension Scheduler {

--- a/Sources/CombineSchedulers/UIScheduler.swift
+++ b/Sources/CombineSchedulers/UIScheduler.swift
@@ -1,5 +1,5 @@
-#if canImport(Combine)
-  import Combine
+#if canImport(OpenCombineShim)
+  import OpenCombineShim
   import Dispatch
 
   /// A scheduler that executes its work on the main queue as soon as possible.

--- a/Sources/CombineSchedulers/UnimplementedScheduler.swift
+++ b/Sources/CombineSchedulers/UnimplementedScheduler.swift
@@ -1,5 +1,5 @@
-#if canImport(Combine)
-  import Combine
+#if canImport(OpenCombineShim)
+  import OpenCombineShim
   import Foundation
   import XCTestDynamicOverlay
 
@@ -270,5 +270,5 @@
   /// by the time type and options type.
   public typealias UnimplementedSchedulerOf<Scheduler> = UnimplementedScheduler<
     Scheduler.SchedulerTimeType, Scheduler.SchedulerOptions
-  > where Scheduler: Combine.Scheduler
+  > where Scheduler: CombineScheduler
 #endif

--- a/Tests/CombineSchedulersTests/ImmediateSchedulerTests.swift
+++ b/Tests/CombineSchedulersTests/ImmediateSchedulerTests.swift
@@ -1,4 +1,4 @@
-import Combine
+import OpenCombineShim
 import CombineSchedulers
 import XCTest
 

--- a/Tests/CombineSchedulersTests/TestSchedulerTests.swift
+++ b/Tests/CombineSchedulersTests/TestSchedulerTests.swift
@@ -1,4 +1,4 @@
-import Combine
+import OpenCombineShim
 import CombineSchedulers
 import XCTest
 

--- a/Tests/CombineSchedulersTests/TimerTests.swift
+++ b/Tests/CombineSchedulersTests/TimerTests.swift
@@ -1,4 +1,4 @@
-import Combine
+import OpenCombineShim
 import CombineSchedulers
 import XCTest
 
@@ -76,6 +76,7 @@ final class TimerTests: XCTestCase {
     )
   }
 
+#if canImport(Combine) // no `MergeMany` in OpenCombine
   func testInterleavingTimers() {
     let scheduler = DispatchQueue.test
 
@@ -105,6 +106,7 @@ final class TimerTests: XCTestCase {
     scheduler.advance(by: 1)
     XCTAssertEqual(output, [1, 2, 1, 1, 2])
   }
+#endif
 
   func testTimerCancellation() {
     let scheduler = DispatchQueue.test

--- a/Tests/CombineSchedulersTests/UISchedulerTests.swift
+++ b/Tests/CombineSchedulersTests/UISchedulerTests.swift
@@ -1,4 +1,4 @@
-import Combine
+import OpenCombineShim
 import CombineSchedulers
 import XCTest
 

--- a/Tests/CombineSchedulersTests/UnimplementedSchedulerTests.swift
+++ b/Tests/CombineSchedulersTests/UnimplementedSchedulerTests.swift
@@ -1,5 +1,6 @@
-#if compiler(>=5.4)
-  import Combine
+// XCTExpectFailure doesn't exist on non Darwin platforms as of 2023-05-22
+#if compiler(>=5.4) && canImport(Darwin)
+  import OpenCombineShim
   import CombineSchedulers
   import XCTest
 


### PR DESCRIPTION
this makes CombineSchedulers work with OpenCombine, and more specifically, OpenCombineShims, allowing to use `Combine` on supported platforms and `OpenCombine` anywhere else.

This helps in the transition of TCA to windows, allowing to build with OpenCombine for now.


While we have the external PR open, we can update our internal develop branch to have the windows code and start collapsing our internal stack since the Pointfree folks might take a bit to evaluate our approach.